### PR TITLE
Added the missing part of the type definition of the signal construction in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ function Counter() {
 ### useSignalConstructor
 
 ```typescript
+type SignalConstructor<Value> = () => Signal<Value>;
+
 const useSignalConstructor: <Value>(signalConstructor: SignalConstructor<Value>) => Value;
 ```
 


### PR DESCRIPTION
## Major Changes
None.

## Minor Changes
None.

## Bug Fixes
- [ ] Fixes #13 

## Security Fixes
None.

## Description
There was a missing bit in the documentation for the `useSignalConstructor` that has been now fixed and adedd back.

## Checklist
- [x] I have tested the changes locally.
- [x] The code follows the project's coding standards.
- [x] I have updated the documentation as necessary.
- [x] The pull request is linked to the relevant issue(s).

## Additional Comments
None.