### PR TITLE
Fix for the must call super before this error

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
+import App from './App'
 import { BrowserRouter } from "react-router-dom";
 
 const root = document.getElementById("root");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "esnext",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
@@ -8,7 +8,6 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
## Major Changes
None.

## Minor Changes
None.

## Bug Fixes
- [ ] Fixes #24 

## Security Fixes
None.

## Description
This pull request fixes a nasty bug that happen when using any `StorageSignal` classes. This bug was caused by a misconfiguration of the project when creating the Vite.js template with Rollup.

## Checklist
- [x] I have tested the changes locally.
- [x] The code follows the project's coding standards.
- [x] I have updated the documentation as necessary.
- [x] The pull request is linked to the relevant issue(s).

## Additional Comments
None.